### PR TITLE
Add client secret to signet auth

### DIFF
--- a/lib/bing_ads_ruby_sdk/oauth2/authorization_handler.rb
+++ b/lib/bing_ads_ruby_sdk/oauth2/authorization_handler.rb
@@ -9,8 +9,8 @@ module BingAdsRubySdk
       # @param developer_token
       # @param client_id
       # @param store [Store]
-      def initialize(developer_token:, client_id:, store:)
-        @client = build_client(developer_token, client_id)
+      def initialize(developer_token:, client_id:, store:, client_secret:)
+        @client = build_client(developer_token, client_id, client_secret)
         @store  = store
         refresh_from_store
       end
@@ -73,11 +73,12 @@ module BingAdsRubySdk
         query_params.find { |arg| arg.first.casecmp("CODE").zero? }
       end
 
-      def build_client(developer_token, client_id)
+      def build_client(developer_token, client_id, client_secret)
         Signet::OAuth2::Client.new({
           authorization_uri:    'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
           token_credential_uri: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
           redirect_uri:         'https://login.microsoftonline.com/common/oauth2/nativeclient',
+          client_secret:        client_secret,
           developer_token: developer_token,
           client_id: client_id,
           scope: 'offline_access'

--- a/tasks/bing_ads_ruby_sdk.rake
+++ b/tasks/bing_ads_ruby_sdk.rake
@@ -2,17 +2,19 @@ require 'dotenv/load'
 
 namespace :bing_token do
   desc "Gets and stores Bing OAuth token in file"
-  task :get, [:filename, :bing_developer_token, :bing_client_id] do |task, args|
+  task :get, [:filename, :bing_developer_token, :bing_client_id, :bing_client_secret] do |task, args|
 
     filename = args[:filename] || ENV.fetch('BING_STORE_FILENAME')
     developer_token = args[:bing_developer_token] || ENV.fetch('BING_DEVELOPER_TOKEN')
     bing_client_id = args[:bing_client_id] || ENV.fetch('BING_CLIENT_ID')
+    bing_client_secret = args[:bing_client_secret] || ENV.fetch('BING_CLIENT_SECRET')
 
     store = ::BingAdsRubySdk::OAuth2::FsStore.new(filename)
     auth = BingAdsRubySdk::OAuth2::AuthorizationHandler.new(
       developer_token: developer_token,
       client_id: bing_client_id,
-      store: store
+      store: store,
+      client_secret: bing_client_secret
     )
     puts "Go to #{auth.code_url}",
          "You will be redirected to a URL at the end. Paste it here in the console and press enter"


### PR DESCRIPTION
Description
Adding Bing Client Secret as an argument to `bing_token:get` and passing it through to Signet.