### PR TITLE
PERF-1463 Optional OAuth client secret

### DIFF
--- a/lib/bing_ads_ruby_sdk/api.rb
+++ b/lib/bing_ads_ruby_sdk/api.rb
@@ -27,13 +27,15 @@ module BingAdsRubySdk
                    environment: :production,
                    developer_token:,
                    client_id:,
-                   oauth_store:)
+                   oauth_store:,
+                   client_secret: nil)
       @version = version
       @environment = environment
       @header = Header.new(
         developer_token: developer_token,
         client_id: client_id,
-        store: oauth_store
+        store: oauth_store,
+        client_secret: client_secret
       )
     end
 

--- a/lib/bing_ads_ruby_sdk/header.rb
+++ b/lib/bing_ads_ruby_sdk/header.rb
@@ -6,11 +6,12 @@ module BingAdsRubySdk
     # @param developer_token
     # @param client_id
     # @param store instance of a store
-    def initialize(developer_token:, client_id:, store:)
+    def initialize(developer_token:, client_id:, store:, client_secret: nil)
       @developer_token = developer_token
       @client_id = client_id
       @oauth_store = store
       @customer = {}
+      @client_secret = client_secret
     end
 
     # @return [Hash] Authorization and identification data that will be added to the SOAP header
@@ -20,7 +21,7 @@ module BingAdsRubySdk
         "DeveloperToken" =>      developer_token,
         "CustomerId" =>          customer[:customer_id],
         "CustomerAccountId" =>   customer[:account_id]
-      }
+      }.merge(client_secret ? { "ClientSecret" => client_secret } : {})
     end
 
     def set_customer(account_id:, customer_id:)
@@ -31,13 +32,14 @@ module BingAdsRubySdk
 
     private
 
-    attr_reader :oauth_store, :developer_token, :client_id, :customer
+    attr_reader :oauth_store, :developer_token, :client_id, :customer, :client_secret
 
     def auth_handler
       @auth_handler ||= ::BingAdsRubySdk::OAuth2::AuthorizationHandler.new(
         developer_token: developer_token,
         client_id: client_id,
-        store: oauth_store
+        store: oauth_store,
+        client_secret: client_secret
       )
     end
   end

--- a/lib/bing_ads_ruby_sdk/oauth2/authorization_handler.rb
+++ b/lib/bing_ads_ruby_sdk/oauth2/authorization_handler.rb
@@ -9,8 +9,8 @@ module BingAdsRubySdk
       # @param developer_token
       # @param client_id
       # @param store [Store]
-      def initialize(developer_token:, client_id:, store:)
-        @client = build_client(developer_token, client_id)
+      def initialize(developer_token:, client_id:, store:, client_secret: nil)
+        @client = build_client(developer_token, client_id, client_secret)
         @store  = store
         refresh_from_store
       end
@@ -73,7 +73,7 @@ module BingAdsRubySdk
         query_params.find { |arg| arg.first.casecmp("CODE").zero? }
       end
 
-      def build_client(developer_token, client_id)
+      def build_client(developer_token, client_id, client_secret=nil)
         Signet::OAuth2::Client.new({
           authorization_uri:    'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
           token_credential_uri: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
@@ -81,7 +81,7 @@ module BingAdsRubySdk
           developer_token: developer_token,
           client_id: client_id,
           scope: 'offline_access'
-        })
+        }.merge(client_secret ? { client_secret: client_secret } : {}))
       end
 
       def token_data

--- a/spec/bing_ads_ruby_sdk/header_spec.rb
+++ b/spec/bing_ads_ruby_sdk/header_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe BingAdsRubySdk::Header do
   end
 
   before do
-    expect(::BingAdsRubySdk::OAuth2::AuthorizationHandler).to receive(:new).with(
+    expect(::BingAdsRubySdk::OAuth2::AuthorizationHandler).to receive(:new).with(hash_including(
       developer_token: '123abc',
       client_id: '1a-2b-3c',
       store: oauth_store
-    ).and_return auth_handler
+    )).and_return auth_handler
   end
 
   describe '.content' do

--- a/tasks/bing_ads_ruby_sdk.rake
+++ b/tasks/bing_ads_ruby_sdk.rake
@@ -2,17 +2,19 @@ require 'dotenv/load'
 
 namespace :bing_token do
   desc "Gets and stores Bing OAuth token in file"
-  task :get, [:filename, :bing_developer_token, :bing_client_id] do |task, args|
+  task :get, [:filename, :bing_developer_token, :bing_client_id, :bing_client_secret] do |task, args|
 
     filename = args[:filename] || ENV.fetch('BING_STORE_FILENAME')
     developer_token = args[:bing_developer_token] || ENV.fetch('BING_DEVELOPER_TOKEN')
     bing_client_id = args[:bing_client_id] || ENV.fetch('BING_CLIENT_ID')
+    bing_client_secret = args[:bing_client_secret] || ENV.fetch('BING_CLIENT_SECRET')
 
     store = ::BingAdsRubySdk::OAuth2::FsStore.new(filename)
     auth = BingAdsRubySdk::OAuth2::AuthorizationHandler.new(
       developer_token: developer_token,
       client_id: bing_client_id,
-      store: store
+      store: store,
+      client_secret: bing_client_secret
     )
     puts "Go to #{auth.code_url}",
          "You will be redirected to a URL at the end. Paste it here in the console and press enter"


### PR DESCRIPTION
Some Bing/Azure apps require "client secret" - especially apps created earlier in MS live dev console, passing client secret it optional and shouldn't affect apps created without secret.

This is proper and complete implementation of #9