### PR TITLE
Allow newer signet v0.14.0

### DIFF
--- a/bing_ads_ruby_sdk.gemspec
+++ b/bing_ads_ruby_sdk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'signet', '>= 0.8.1', '< 0.13.0'
+  spec.add_runtime_dependency 'signet', '>= 0.8.1', '<= 0.14.0'
   spec.add_runtime_dependency 'excon', '>= 0.62.0'
   spec.add_runtime_dependency 'lolsoap', '>=0.9.0'
 


### PR DESCRIPTION
bump signet to latest version to allow newer version of `faraday`. signet prior to v0.13.0 only allows faraday version 0.x so if you using faraday in your project beside signet it's being locked at 0.x version without possibility to upgrade to v1.0