### PR TITLE
Fix build config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "./lib/bing_ads_ruby_sdk"
-import "tasks/bing_ads_ruby_sdk.rake"
+import "lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake"
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/bing_ads_ruby_sdk.gemspec
+++ b/bing_ads_ruby_sdk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Effilab/bing_ads_ruby_sdk"
   spec.license = "MIT"
 
-  spec.files = `git ls-files`.split($/)
+  spec.files = Dir["README.md", "VERSION", "Gemfile", "Rakefile", "{bin,lib}/**/*"]
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 

--- a/bing_ads_ruby_sdk.gemspec
+++ b/bing_ads_ruby_sdk.gemspec
@@ -15,7 +15,15 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Effilab/bing_ads_ruby_sdk"
   spec.license = "MIT"
 
-  spec.files = Dir["README.md", "Gemfile", "Rakefile", "{bin,lib}/**/*"]
+  spec.files = Dir[
+    "bing_ads_ruby_sdk.gemspec",
+    "changelog.md",
+    "README.md",
+    "Gemfile",
+    "Rakefile",
+    "LICENSE.txt",
+    "{bin,lib,tasks}/**/*"
+  ]
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 

--- a/bing_ads_ruby_sdk.gemspec
+++ b/bing_ads_ruby_sdk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Effilab/bing_ads_ruby_sdk"
   spec.license = "MIT"
 
-  spec.files = Dir["README.md", "VERSION", "Gemfile", "Rakefile", "{bin,lib}/**/*"]
+  spec.files = Dir["README.md", "Gemfile", "Rakefile", "{bin,lib}/**/*"]
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
## Features

* Fixes `bundle exec rake build`
  * Fix path reference in Rakefile
  * Use a better syntax for including files in the `.gem` file
  * Include gem files instead of creating an empty `.gem` file

## Tests run on this branch
* CI :heavy_check_mark: 
* Gem builds and the code in the gem now contains all the files I expected :heavy_check_mark: 
* Install the `.gem` file in a project (using `path: ...`), run tests using the API :heavy_check_mark: 
* Build the `.gem` for the latest version and compare the file contents with `v1.3.0` :heavy_check_mark: 
  * The only difference in the files included are the ones that were changed between versions
  * ... with the exception of the `spec/` folder which I don't think we should include in the gem