### PR TITLE
Efftech 2346 - Envkey v2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -210,7 +210,7 @@
         "envkey"
       ],
       "automerge": true,
-      "allowedVersions": "<2",
+      "allowedVersions": "<3",
       "groupName": "envkey-update",
       "description": "no switch for now"
     },

--- a/lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake
+++ b/lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake
@@ -1,6 +1,7 @@
 begin
   require "dotenv/load"
 rescue LoadError
+  puts "Unable to load .env file, resuming..."
 end
 
 

--- a/lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake
+++ b/lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake
@@ -1,4 +1,8 @@
-require "dotenv/load"
+begin
+  require "dotenv/load"
+rescue LoadError
+end
+
 
 namespace :bing_token do
   desc "Gets OAuth token from MS and stores it in a JSON file defined by filename parameter"

--- a/lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake
+++ b/lib/bing_ads_ruby_sdk/tasks/bing_ads_ruby_sdk.rake
@@ -4,7 +4,6 @@ rescue LoadError
   puts "Unable to load .env file, resuming..."
 end
 
-
 namespace :bing_token do
   desc "Gets OAuth token from MS and stores it in a JSON file defined by filename parameter"
   task :get, [:filename, :bing_developer_token, :bing_client_id, :bing_client_secret] do |task, args|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 require "simplecov"
-require "dotenv/load"
 require "byebug"
+
+begin
+  require "dotenv/load"
+rescue LoadError
+  puts "Unable to load .env file, resuming..."
+end
 
 SimpleCov.start do
   add_filter "/spec/"


### PR DESCRIPTION
The problem is :

Our gem relies on the dotenv gem
The dotenv gem is just required for ⁠[development](https://github.com/Effilab/bing_ads_ruby_sdk/blob/master/bing_ads_ruby_sdk.gemspec) (as it is supposed to be, as said the dotenv gem github readme)
The dotenv gem is required at the top of our rake files, so Rails loading the gem in any environment other than development is failing
It was working for us until now because by chance Envkey v1 gem used the dotenv gem as a dependency, and it's not the case for envkey v2 so BSA is failing now