### PR TITLE
fix multiple errors occuring at account level

### DIFF
--- a/lib/bing_ads_ruby_sdk/errors/errors.rb
+++ b/lib/bing_ads_ruby_sdk/errors/errors.rb
@@ -88,7 +88,7 @@ module BingAdsRubySdk
       def first_error_message(error_list)
         error = error_list.first.values.first
         if error.is_a? Array
-          error=error.first
+          error = error.first
         end
         format_message(error[:error_code], error[:message])
       end

--- a/lib/bing_ads_ruby_sdk/errors/errors.rb
+++ b/lib/bing_ads_ruby_sdk/errors/errors.rb
@@ -45,12 +45,7 @@ module BingAdsRubySdk
         error_list = all_errors
         return @message if error_list.empty?
 
-        first_message = first_error_message(error_list)
-        if error_list.count > 1
-          "API raised #{error_list.count} errors, including: #{first_message}"
-        else
-          first_message
-        end
+        concatenated_error_messages(error_list)
       end
 
       private
@@ -85,12 +80,18 @@ module BingAdsRubySdk
         BingAdsRubySdk::StringUtils.snakize(class_name).to_sym
       end
 
-      def first_error_message(error_list)
-        error = error_list.first.values.first
-        if error.is_a? Array
-          error = error.first
-        end
-        format_message(error[:error_code], error[:message])
+      def concatenated_error_messages(error_list)
+        errors = error_list.map do |error|
+          if error.is_a?(Hash) && error[:error_code]
+            error
+          else
+            error.values
+          end
+        end.flatten.compact
+
+        errors.map do |error|
+          format_message(error[:error_code], error[:message])
+        end.uniq.join(", ")
       end
 
       def array_wrap(value)
@@ -126,13 +127,13 @@ module BingAdsRubySdk
         raw_response[fault_key] || {}
       end
 
-      # Gets the first error message in the list. This is
-      # overridden because partial errors are structured differently
+      # This is overridden because partial errors are structured differently
       # to application faults
       # @return [Hash] containing the details of the error
-      def first_error_message(error_list)
-        error = error_list.first
-        format_message(error[:error_code], error[:message])
+      def concatenated_error_messages(error_list)
+        error_list.map do |error|
+          format_message(error[:error_code], error[:message])
+        end.uniq.join(", ")
       end
     end
 

--- a/lib/bing_ads_ruby_sdk/errors/errors.rb
+++ b/lib/bing_ads_ruby_sdk/errors/errors.rb
@@ -57,7 +57,7 @@ module BingAdsRubySdk
 
       def populate_error_lists
         self.class.error_lists.each do |key|
-          instance_variable_set("@#{key}", array_wrap(fault_hash[key]))
+          instance_variable_set(:"@#{key}", array_wrap(fault_hash[key]))
         end
       end
 
@@ -87,6 +87,9 @@ module BingAdsRubySdk
 
       def first_error_message(error_list)
         error = error_list.first.values.first
+        if error.is_a? Array
+          error=error.first
+        end
         format_message(error[:error_code], error[:message])
       end
 

--- a/spec/bing_ads_ruby_sdk/errors/error_handler_spec.rb
+++ b/spec/bing_ads_ruby_sdk/errors/error_handler_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe BingAdsRubySdk::Errors::ErrorHandler do
 
       context "when all the lists have errors" do
         let(:error_message) do
-          "API raised 3 errors, including: ErrorCode - Batch error message"
+          "ErrorCode - Batch error message, TypeInvalid - The campaign criterion ..."
         end
         it("raises an error") { shared_expectations }
       end
@@ -314,7 +314,7 @@ RSpec.describe BingAdsRubySdk::Errors::ErrorHandler do
         let(:error_attributes) do
           {
             raw_response: api_response,
-            message: "The business address of this account is required."
+            message: "The business address of this account is required., The business address of this account is not valid."
           }
         end
 
@@ -409,7 +409,7 @@ RSpec.describe BingAdsRubySdk::Errors::ErrorHandler do
     end
   end
 
-  context "when there are partial errors - multiple batch_errors" do
+  context "when there are partial errors - multiple identical batch_errors" do
     let(:api_response) do
       {
         campaign_ids: [],
@@ -446,7 +446,7 @@ RSpec.describe BingAdsRubySdk::Errors::ErrorHandler do
       let(:error_attributes) do
         {
           raw_response: api_response,
-          message: "API raised 2 errors, including: UnsupportedBiddingScheme - The bidding..."
+          message: "UnsupportedBiddingScheme - The bidding..."
         }
       end
 

--- a/spec/bing_ads_ruby_sdk/errors/error_handler_spec.rb
+++ b/spec/bing_ads_ruby_sdk/errors/error_handler_spec.rb
@@ -303,9 +303,10 @@ RSpec.describe BingAdsRubySdk::Errors::ErrorHandler do
             api_fault: {
               tracking_id: "14f89175-e806-4822-8aa7-32b0c7734e11",
               batch_errors: "",
-              operation_errors: [{:operation_error=>
-                                    [{:code=>"1139", :details=>"", :message=>"The business address of this account is required."},
-                                     {:code=>"1140", :details=>"", :message=>"The business address of this account is not valid."}]}]
+              operation_errors: [
+                {operation_error: [{code: "1139", details: "", message: "The business address of this account is required."},
+                  {code: "1140", details: "", message: "The business address of this account is not valid."}]}
+              ]
             }
           }
         end

--- a/spec/bing_ads_ruby_sdk/errors/error_handler_spec.rb
+++ b/spec/bing_ads_ruby_sdk/errors/error_handler_spec.rb
@@ -296,6 +296,29 @@ RSpec.describe BingAdsRubySdk::Errors::ErrorHandler do
       end
 
       it("raises an error") { shared_expectations }
+
+      context "when there are several errors without error_code" do
+        let(:detail) do
+          {
+            api_fault: {
+              tracking_id: "14f89175-e806-4822-8aa7-32b0c7734e11",
+              batch_errors: "",
+              operation_errors: [{:operation_error=>
+                                    [{:code=>"1139", :details=>"", :message=>"The business address of this account is required."},
+                                     {:code=>"1140", :details=>"", :message=>"The business address of this account is not valid."}]}]
+            }
+          }
+        end
+
+        let(:error_attributes) do
+          {
+            raw_response: api_response,
+            message: "The business address of this account is required."
+          }
+        end
+
+        it("raises an error") { shared_expectations }
+      end
     end
   end
 

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -1,3 +1,6 @@
+require "ostruct"
+require "nokogiri"
+
 module SpecHelpers
   def self.request_xml_for(service, action, filename)
     Nokogiri::XML(File.read(xml_path_for(service, action, filename)))


### PR DESCRIPTION
When using the console of an  app that requires the SDK:
before :
```
> @err.message
.../lib/irb.rb:1260:in `full_message': no implicit conversion of Symbol into Integer (TypeError)
        format_message(error[:error_code], error[:message])    
```

after :
```
> @err.message
=> "The business address of this account is required., The business address of this account is not valid."
```